### PR TITLE
TextAreaItem - allowing \n and \" in textarea

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/TextAreaItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/TextAreaItem.java
@@ -93,6 +93,11 @@ public class TextAreaItem extends FormItem<String> {
     }
 
     @Override
+    public String asString() {
+        return textArea.getValue();
+    }
+
+    @Override
     public void resetMetaData() {
         super.resetMetaData();
         textArea.setValue(null);


### PR DESCRIPTION
This trivial patch allow characters `\n` and `"` in property values.
I also thing that adding support of newlines in multiline textarea items is good idea.
(DMR properties works correctly with it, only web console have problem with it.)

**Before this patch cause character `"` poorly trackable UmbrellaException:**

```
[ERROR] 2014-04-16 10:20:07,512 [FATAL] Uncaught Exception:
[ERROR] com.google.gwt.event.shared.UmbrellaException: Exception caught: Could not parse payload
[ERROR] Caused by: java.lang.RuntimeException: Could not parse payload
[ERROR] Caused by: org.json.JSONException: Expected a ',' or '}' at character 68
[ERROR]     at org.json.JSONTokener.syntaxError(JSONTokener.java:410)
```

In WildFly web console visible only as not saving without any error message. (Only exception in GWT debug)
