### PR TITLE
[HAL-889] [JBEAP-1361] call setUndefined() as per changed value in Ch…

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/CheckBoxItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/CheckBoxItem.java
@@ -69,6 +69,7 @@ public class CheckBoxItem extends FormItem<Boolean> {
             @Override
             public void onValueChange(ValueChangeEvent<Boolean> booleanValueChangeEvent) {
                 setModified(true);
+                setUndefined(false);
             }
         });
         setUndefined(false);


### PR DESCRIPTION
…eckBoxItem.
https://issues.jboss.org/browse/HAL-889 https://issues.jboss.org/browse/JBEAP-1361

CheckBoxItem does not reset boolean value "isUndefined" when its value changed. Thus, for any initial undefined attribute, it remains undefined as described in HAL-889