### PR TITLE
[HAL-1004] set index if display.getRowCount() <= pageSize

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/tables/DefaultPager.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/tables/DefaultPager.java
@@ -48,7 +48,7 @@ public class DefaultPager extends SimplePager {
         if (display != null) {
             Range range = display.getVisibleRange();
             int pageSize = range.getLength();
-            if (!isRangeLimited() && display.isRowCountExact()) {
+            if ((!isRangeLimited() || display.getRowCount() <= pageSize) && display.isRowCountExact()) {
                 index = Math.min(index, display.getRowCount() - pageSize);
             }
             index = Math.max(0, index);


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1004 fix the regression introduced in https://issues.jboss.org/browse/HAL-279 commit https://github.com/hal/ballroom/commit/ce355da549b90e4a25f7e1a50a26d9150e326d03#diff-5f94a7a11f03cc1ebc58e7f3fdf3d04a

filtered search in table can not render properly if filtered value length is smaller than page size. see reproduced step f in HAL-1004 description