### PR TITLE
[HAL-1125] Setting system properties on a server-group fails when using RBAC scoped roles on admin console

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/tools/ToolStrip.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/tools/ToolStrip.java
@@ -162,12 +162,16 @@ public class ToolStrip extends HorizontalPanel implements SecurityContextAware {
                     granted = overallPrivilege; // coarse grained, inherited from parent
                 }
 
+                btn.setVisible(granted);
+
                 if (update) {
-                    btn.setVisible(true);
-                    btn.setEnabled(granted);
-                    visibleButtons++;
+                    if (granted) {
+                        widget.getElement().removeClassName("rbac-suppressed");
+                        visibleButtons++;
+                    } else {
+                        widget.getElement().addClassName("rbac-suppressed");
+                    }
                 } else {
-                    btn.setVisible(granted);
                     if (!granted) {
                         widget.getElement().addClassName("rbac-suppressed");
                     }


### PR DESCRIPTION
HAL upstream Jira: https://issues.jboss.org/browse/HAL-1125

There are two ways to address the issue:
 1) adding/removing "rbac-supressed" class which will make the buttons and ToolStrip visible based on privilege,
 2) setting enabled based on privilege which means that buttons will be visible (but disabled) even if the user does not have the privilege.
I went with the first option as it seems to me that it is closer to the original intent.

Question: shall I create new HAL issue to update "ballroom.version" in HAL core?