### PR TITLE
[BZ-1343591] setting system properties on a server-group fails when using RBAC scoped roles on admin console

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/tools/ToolStrip.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/tools/ToolStrip.java
@@ -152,12 +152,16 @@ public class ToolStrip extends HorizontalPanel implements SecurityContextAware {
                     granted = overallPrivilege; // coarse grained, inherited from parent
                 }
 
+                btn.setVisible(granted);
+
                 if (update) {
-                    btn.setVisible(true);
-                    btn.setEnabled(granted);
-                    visibleButtons++;
+                    if (granted) {
+                        widget.getElement().removeClassName("rbac-suppressed");
+                        visibleButtons++;
+                    } else {
+                        widget.getElement().addClassName("rbac-suppressed");
+                    }
                 } else {
-                    btn.setVisible(granted);
                     if (!granted) {
                         widget.getElement().addClassName("rbac-suppressed");
                     }


### PR DESCRIPTION
EAP6 BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1343591
Upstream/EAP7 Jira: https://issues.jboss.org/browse/JBEAP-5065

Upstream PR: https://github.com/hal/ballroom/pull/10

Related to PR: https://github.com/hal/core/pull/255