### PR TITLE
Remove mentions of deleted module 'showcase' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,6 @@ Participating in Ballroom
 * Mailing List: https://lists.jboss.org/mailman/listinfo/jboss-as7-dev
 * IRC: irc://irc.freenode.org/jboss-as7
 
-Running the showcase
---------------------
-The showcase should give an idea what widgets exists and what functionality they offer.
-It's work in progress and subject to continuous improvements. But in general the widget set
-should be kept small and straight forward. 
-
-Running the showcase is simple:
-
-	cd showcase
-	mvn clean gwt:run
-	
-
 Using ballroom in your project
 ------------------------------
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ About Ballroom
 Ballroom is a shared widget library for JBoss projects that build on GWT.
 Prominent samples are:
 
-* Drools Guvnor 
-* JBossAS 7 
-* Riftsaw 
+* Drools Guvnor
+* JBossAS 7
+* Riftsaw
 * JBPM 5
 * Savarra
 
@@ -25,21 +25,21 @@ In order to use ballroom you need to import the GWT module descriptor:
 	<module>
 
 		<inherits name="org.jboss.as.console.Framework"/>
-	
+
 		[...]
-		
+
 		<replace-with class="org.jboss.as.console.spi.NoopFramework">
 	        <when-type-is class="org.jboss.as.console.client.spi.Framework"/>
 	    </replace-with>
-		
+
 	</module>
-	
+
 Ballroom ships with two different styles. One for jboss.org projects and another one for branded RH products:
 
 
 	* <inherits name="org.jboss.as.console.Framework"/>
 	* <inherits name="org.jboss.as.console.Framework_RH"/>
-	
+
 Library dependencies
 --------------------
 
@@ -48,8 +48,8 @@ if you want to leverage all provided widgets. Apart from GWT > 2.2, ballroom dep
 
 * GWT Event Bus
 * AutoBean Factory
-* GWTP PlaceManager 
-	
+* GWTP PlaceManager
+
 These framework dependencies are provided through an simple SPI interface:
 
 	public interface Framework {
@@ -58,22 +58,22 @@ These framework dependencies are provided through an simple SPI interface:
 	    PlaceManager getPlaceManager();
 	    AutoBeanFactory getBeanFactory();
 	}
-	
+
 A specific implementation is declared through the module descriptor:
 
 	<module>
-		
+
 		[...]
-		
+
 		<replace-with class="org.jboss.as.console.client.spi.NoopFramework">
 	        <when-type-is class="org.jboss.as.console.client.spi.Framework"/>
 	    </replace-with>
-		
+
 		[...]
-		
+
 	</module>
-	
-	
+
+
 Releasing ballroom
 ------------------
 


### PR DESCRIPTION
I did not find any trace of the 'showcase' module, but if it is still around, obviously, it would be best to add link to the proper place to find it ! :)