### PR TITLE
HAL-1315 `enabling` input value is rewriten...

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/AbstractForm.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/AbstractForm.java
@@ -358,6 +358,10 @@ public abstract class AbstractForm<T> implements FormAdapter<T> {
         setFieldsInGroup(group, renderer, flatten(items));
     }
 
+    public void clearGroup(String group) {
+        this.formItems.remove(group);
+    }
+
     private FormItem<?>[] flatten(FormItem<?>[]... items) {
         List<FormItem<?>> l = new ArrayList<FormItem<?>>();
         for (FormItem<?> [] fiArray : items) {


### PR DESCRIPTION
...in Configurable HTTP Server Mechanism filter

* adding a method that allows removing item group from a form (currently
the items can be removed from the group, but the *empty* group stays
present and is then rendered in the form)

https://issues.jboss.org/browse/HAL-1315
https://issues.jboss.org/browse/JBEAP-9569