### PR TITLE
[JBEAP-12293] - Cannot add new credential store with credential reference store field

### DIFF
--- a/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/FormItem.java
+++ b/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/FormItem.java
@@ -156,8 +156,13 @@ public abstract class FormItem<T> implements InputElement<T>, Comparable<String>
 
     public enum VALUE_SEMANTICS {UNDEFINED}
 
-    Element getInputElement() {
+    public Element getInputElement() {
         return null;
+    }
+
+    public void focus(){
+        if(getInputElement() != null)
+            getInputElement().focus();
     }
 
     protected void toggleExpressionInput(Widget target, boolean flag)


### PR DESCRIPTION

Added focus() method to FormItem and made getInputElement public.

JBEAP issue: https://issues.jboss.org/browse/JBEAP-12293
HAL issue: https://issues.jboss.org/browse/HAL-1371